### PR TITLE
bug(*): error in list if contains a dash

### DIFF
--- a/store_test.go
+++ b/store_test.go
@@ -119,6 +119,7 @@ var listTestMap = map[string]string{
 	"/deis/database/user":            "user",
 	"/deis/database/pass":            "pass",
 	"/deis/services/key":             "value",
+	"/deis/services/with-space":      "ok",
 	"/deis/services/notaservice/foo": "bar",
 	"/deis/services/srv1/node1":      "10.244.1.1:80",
 	"/deis/services/srv1/node2":      "10.244.1.2:80",
@@ -132,7 +133,7 @@ func TestList(t *testing.T) {
 	for k, v := range listTestMap {
 		s.Set(k, v)
 	}
-	want := []string{"key", "notaservice", "srv1", "srv2"}
+	want := []string{"key", "notaservice", "srv1", "srv2", "with-space"}
 	paths := []string{
 		"/deis/services",
 		"/deis/services/",
@@ -162,7 +163,7 @@ func TestListDir(t *testing.T) {
 	for k, v := range listTestMap {
 		s.Set(k, v)
 	}
-	want := []string{"notaservice", "srv1", "srv2"}
+	want := []string{"key", "notaservice", "srv1", "srv2", "with-space"}
 	paths := []string{
 		"/deis/services",
 		"/deis/services/",


### PR DESCRIPTION
If https://github.com/deis/memkv/blob/master/store.go#L146 not commented there's an error if the key contains a dash

```
aledbf:memkv aledbf$ go test
--- FAIL: TestListDir (0.00s)
    store_test.go:174: List(/deis/services) = [notaservice srv1 srv2], want [key notaservice srv1 srv2 with-space]
    store_test.go:174: List(/deis/services/) = [notaservice srv1 srv2], want [key notaservice srv1 srv2 with-space]
FAIL
exit status 1
FAIL    github.com/aledbf/memkv 0.004s
```

with https://github.com/deis/memkv/blob/master/store.go#L146 commented it pass

```
aledbf:memkv aledbf$ go test
PASS
ok      github.com/aledbf/memkv 0.004s
```
